### PR TITLE
extend header bg color to edge of the screen

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -85,10 +85,6 @@ a {
 	text-decoration: none;
 }
 
-.layout > * {
-	padding: 1.5em;
-}
-
 @media (min-width: 40em) {
 	.layout {
 		grid-template-columns: 20em 1fr;
@@ -100,7 +96,11 @@ a {
 	}
 
 	header {
-		margin: 5em auto 0;
+		padding: 10em 1.5em 0;
+	}
+
+	header h1 {
+		margin: 0 auto;
 	}
 }
 


### PR DESCRIPTION
Addresses issue #1 

This PR fixes the issue of the header background color not extending to the edge of the screen. Now, the bg color extends all the way to the top, bottom, and left edges of the screen